### PR TITLE
Test suite updates

### DIFF
--- a/src/python/test_suite/README.md
+++ b/src/python/test_suite/README.md
@@ -61,6 +61,7 @@ Verify dv1, dv2 not present in db, TDS, Solr. Other tests below, where not expli
  * Publish dv1 to Solr.
    * Verify dv1 in Solr.
    * Verify consistency of dv1 in Solr, TDS, versioning and file contents.
+* now implemented as `test_1_verify_publish_single_dataset_single_version`
 
 ###Test 2: Publish second version of dataset [Extends: Test 1]
  * Publish dv2 to db.
@@ -77,6 +78,8 @@ Verify dv1, dv2 not present in db, TDS, Solr. Other tests below, where not expli
    * Verify dv1 in Solr.
    * Verify consistency of dv1 in Solr, TDS, versioning and file contents.
 
+* now implemented as `test_2_verify_publish_single_dataset_two_versions`
+
 ###Test 3: Publish “all” datasets in stages
 
 This is a special test in which all datasets are published at each stage. Success in this test requires overcoming a current problem with the ESG Publisher code. The problem was that the publisher was hard-coded to always use the most recent version in the postgres db.
@@ -89,7 +92,17 @@ This is a special test in which all datasets are published at each stage. Succes
    * Verify all datasets and versions in Solr.
    * Verify consistency of all datasets in Solr, TDS, versioning and file contents.
 
-###Test 4: Publish “all” datasets in stages in reverse order
+* now implemented as `test_3_verify_publish_all_in_stages`
+
+
+###Test 4: Publish “all” datasets in reverse order
+
+* as test 2, but with dv1 and dv2 swapped, i.e. publish dv2 (all stages); publish dv1 (all stages); re-verify dv2 (all stages)
+
+* now implemented as `test_4_verify_publish_in_reverse`
+
+
+###Test 5: Publish “all” datasets in stages in reverse order
 
  * Publish all datasets and versions to db in reverse order.
    * Verify all datasets and versions in db.
@@ -99,7 +112,10 @@ This is a special test in which all datasets are published at each stage. Succes
    * Verify all datasets and versions in Solr.
    * Verify consistency of all datasets in Solr, TDS, versioning and file contents.
 
-###Test 5: Unpublish sole version [Extends: Test 1]
+* now implemented as `test_5_verify_publish_in_reverse_in_stages`   
+
+
+###Test 6: Unpublish sole version [Extends: Test 1]
 
 Run test 1.
 
@@ -110,7 +126,11 @@ Run test 1.
  * Unpublish dv1 from db.
    * Verify dv1 removed from db.
 
-###Test 6: Unpublish latest version of multi-version dataset [Extends: Test 2]
+* now implemented as `test_6_verify_unpublish_sole_version`
+
+
+
+###Test 7: Unpublish latest version of multi-version dataset [Extends: Test 2]
 
 Run test 2.
 
@@ -127,7 +147,10 @@ Run test 2.
    * Verify dv1 in db, TDS and Solr.
    * Verify consistency of dv1 in Solr, TDS, versioning and file contents.
 
-###Test 7: Unpublish old version of multi-version dataset [Extends: Test 2]
+* now implemented as `test_7_verify_unpublish_latest_of_multi_versions`
+
+
+###Test 8: Unpublish old version of multi-version dataset [Extends: Test 2]
 
 Run test 2.
 
@@ -144,10 +167,8 @@ Run test 2.
    * Verify dv2 in db, TDS and Solr.
    * Verify consistency of dv2 in Solr, TDS, versioning and file contents.
 
-###Test 8: Generate mapfiles
+* now implemented as `test_8_verify_unpublish_earliest_of_multi_versions`
 
- * Generate mapfiles.
-   * Verify mapfiles exist and are formatted correctly.
 
 ###Test 9: Parallel publication
 
@@ -163,7 +184,18 @@ This test explores whether it is safe to publish in parallel.
    * Verify all datasets and versions in Solr.
    * Verify consistency of all datasets in Solr, TDS, versioning and file contents.
 
-###Test 10: Parallel publication of multi-version dataset
+* now implemented as `test_9_parallel_publication`
+
+
+###Test 10: Generate mapfiles
+
+ * Generate mapfiles.
+   * Verify mapfiles exist and are formatted correctly.
+
+* not currently implemented.
+
+
+###Test 11: Parallel publication of multi-version dataset
 
 This test explores whether it is safe to publish multiple versions of a dataset at the same time. This checks that the code doesn’t get confused when a new version is appearing in the system (e.g. in the db) whilst a process is running.
 
@@ -175,7 +207,10 @@ This test explores whether it is safe to publish multiple versions of a dataset 
    * Verify all versions in Solr.
    * Verify consistency of all versions in Solr, TDS, versioning and file contents.
 
-###Test 11: Stress testing parallel publication
+* not currently implemented.
+
+
+###Test 12: Stress testing parallel publication
 
 Run parallel publication varying the number of parallel processes to determine the maximum number of concurrent processes that it is safe to run.
 
@@ -183,7 +218,10 @@ Run parallel publication varying the number of parallel processes to determine t
  * Maybe need to use a profiler as well.
  * Results should inform recommendations document...
 
-###Test 12: Publish datasets with different “esg.ini” files
+* not currently implemented.
+
+
+###Test 13: Publish datasets with different “esg.ini” files
 
 This test checks whether using multiple “esg.ini” files (one for each project) cause problems in publication. See GitHub issue:
 https://github.com/ESGF/esg-publisher/issues/8
@@ -194,6 +232,9 @@ https://github.com/ESGF/esg-publisher/issues/8
    * Verify dataset is in db, TDS and Solr
  * Unpublish dataset from project X using appropriate esg_x.ini
    * Verify consistency of Solr and TDS metadata related to dataset from project Y
+
+* not currently implemented.
+
 
 ###Test CEDA1: Publication from a non Data Node*** (CEDA ONLY)
 

--- a/src/python/test_suite/test_suite.ini
+++ b/src/python/test_suite/test_suite.ini
@@ -40,8 +40,8 @@ partest_log_level = WARN
 # and how long to wait between attempts. (A single final test will be allowed
 # to be started after the max_time is reached, in order to allow this full 
 # time for the records to (dis)appear.)
-#solr_verify_max_time = 120
-#solr_verify_sleep_time = 5
+solr_verify_max_time = 120
+solr_verify_sleep_time = 5
 
 
 # uncomment for use on test system where replication 
@@ -49,8 +49,8 @@ partest_log_level = WARN
 # /usr/local/solr-home/slave-8983/*/conf/solrconfig.xml
 # to allow quicker running of test suite.
 
-solr_verify_max_time = 10
-solr_verify_sleep_time = 1
+#solr_verify_max_time = 10
+#solr_verify_sleep_time = 1
 
 
 #

--- a/src/python/test_suite/tests/all_tests.py
+++ b/src/python/test_suite/tests/all_tests.py
@@ -335,10 +335,17 @@ class PublisherTests(unittest.TestCase):
         self.publish_and_verify([ds1, ds2])
     
     @with_log_status
-    def test_4_verify_publish_all_in_reverse(self):   
+    def test_4a_verify_publish_in_reverse(self):
+        self.ensure_empty()
+        self.publish_and_verify(ds2)
+        self.publish_and_verify(ds1)
+        self.verify_published(ds2)
+        
+    @with_log_status
+    def test_4b_verify_publish_in_reverse_in_stages(self):   
         self.ensure_empty()
         self.publish_and_verify([ds2, ds1])
-        
+
     @with_log_status
     def test_5_verify_unpublish_sole_version(self):
         self.ensure_empty()

--- a/src/python/test_suite/tests/all_tests.py
+++ b/src/python/test_suite/tests/all_tests.py
@@ -335,25 +335,25 @@ class PublisherTests(unittest.TestCase):
         self.publish_and_verify([ds1, ds2])
     
     @with_log_status
-    def test_4a_verify_publish_in_reverse(self):
+    def test_4_verify_publish_in_reverse(self):
         self.ensure_empty()
         self.publish_and_verify(ds2)
         self.publish_and_verify(ds1)
         self.verify_published(ds2)
         
     @with_log_status
-    def test_4b_verify_publish_in_reverse_in_stages(self):   
+    def test_5_verify_publish_in_reverse_in_stages(self):   
         self.ensure_empty()
         self.publish_and_verify([ds2, ds1])
 
     @with_log_status
-    def test_5_verify_unpublish_sole_version(self):
+    def test_6_verify_unpublish_sole_version(self):
         self.ensure_empty()
         self.publish_and_verify(ds1)
         self.unpublish_and_verify(ds1)
 
     @with_log_status
-    def test_6_verify_unpublish_latest_of_multi_versions(self):
+    def test_7_verify_unpublish_latest_of_multi_versions(self):
         self.ensure_empty()
         self.publish_and_verify(ds1)
         self.publish_and_verify(ds2)
@@ -361,7 +361,7 @@ class PublisherTests(unittest.TestCase):
         self.verify_published(ds1)
 
     @with_log_status
-    def test_7_verify_unpublish_earliest_of_multi_versions(self):
+    def test_8_verify_unpublish_earliest_of_multi_versions(self):
         self.ensure_empty()
         self.publish_and_verify(ds1)
         self.publish_and_verify(ds2)
@@ -369,7 +369,7 @@ class PublisherTests(unittest.TestCase):
         self.verify_published(ds2)
 
     @with_log_status
-    def test_8_parallel_publication(self):
+    def test_9_parallel_publication(self):
         dsets = datasets.get_parallel_test_datasets()
         pool_step = int(config.get('partest_pool_size_increment'))
         pool_max = int(config.get('partest_pool_size_max'))

--- a/src/python/test_suite/utils/read_thredds.py
+++ b/src/python/test_suite/utils/read_thredds.py
@@ -76,6 +76,12 @@ class ReadThredds(object):
     def _parse_dataset(self, el):
         """
         Parse a single top-level dataset element.  Return Dataset object.
+
+        Raises exception if second-level dataset elements (files and
+        aggregations) do not have their own <variables> children.  This 
+        is a sign of per-time publication, in which case the variable list 
+        is inherited from the top-level dataset even though files might not 
+        contain all the variables present in the dataset.
         """
         # top "dataset" element should be the dataset
         properties = self._get_properties(el)
@@ -89,8 +95,10 @@ class ReadThredds(object):
                 url = ch.get("urlPath")
                 tracking_id = props["tracking_id"]
                 checksum = props["checksum"]
-                size = props["size"]
+                size = props["size"]                
                 ds.add_file(File(url, size, checksum, tracking_id))
+            if not self._get_children_by_tag(ch, "variables"):
+                raise Exception("per-time publication detected")
         return ds
 
     def _get_properties(self, el):

--- a/src/python/test_suite/utils/wrap_esgf_publisher.py
+++ b/src/python/test_suite/utils/wrap_esgf_publisher.py
@@ -22,14 +22,15 @@ class PublishFuncs(object):
     def publish_to_db(self, ds):
         self.logger.debug("doing publish_to_db: %s" % ds.id)
         self.run_command("esgpublish",
-                         "--new-version", str(ds.version),
                          "--project", ds.id.split(".")[0],
+                         "--new-version", str(ds.version),
                          "--map", ds.mapfile_path)
         self.logger.debug("done publish_to_db: %s" % ds.id)
 
     def publish_to_tds(self, ds, thredds_reinit=True):
         self.logger.debug("doing publish_to_tds: %s" % ds.id)
         command = ["esgpublish", 
+                   "--project", ds.id.split(".")[0],
                    "--new-version", str(ds.version),
                    "--noscan",
                    "--thredds",
@@ -43,6 +44,7 @@ class PublishFuncs(object):
     def publish_to_solr(self, ds):
         self.logger.debug("doing publish_to_solr: %s" % ds.id)
         self.run_command("esgpublish", 
+                         "--project", ds.id.split(".")[0],
                          "--new-version", str(ds.version),
                          "--noscan",
                          "--publish",


### PR DESCRIPTION
I could merge myself, but creating a pull request so that @soay is aware of the changes.

In particular, I wish to highlight https://github.com/IS-ENES-Data/esg-publisher/commit/69c5df89f8089ca72218ca90a3b80a824717f159

This is in relation to the per-time problem. What I have done is add a test to check whenever a THREDDS catalog is parsed (whether from the local filesystem or from TDS) to ensure that the second-level `<dataset>` elements (corresponding to files or aggregations) have a child-element called `<variables>`. If they do not, then the test fails, because this is a sign of per-time publication, where the file or aggregation expects to inherit the variable list from the top-level dataset (including variables not present in the file). Note that this check is not in itself a separate top-level test; rather, it is a condition that *all* tests need to satisfy.  However, at present there is no top-level test which exposes the problem, because the existing publish all in reverse test (which publishes all to database before starting on THREDDS) is already failing due to lack of files in one of the datasets.  So what I have now done is split test 4 (publish all in reverse) into two cases: `test_4a_verify_publish_in_reverse`, which publishes the later version in all stages before starting on the earlier version, and `test_4b_verify_publish_in_reverse_in_stages`, which publishes all versions in reverse at each stage before continuing with the next stage. Test 4b is the one which already existed, although the name did not contain "_in_stages", and test 4a is the new one. So, test 4b continues to fail for the other reason, but test 4a currently fails *only* because of the new test for `<variables>` and would otherwise pass if these two new lines were commented out.