### PR TITLE
CIM integration

### DIFF
--- a/src/python/esgcet/esgcet/config/cmip6_handler.py
+++ b/src/python/esgcet/esgcet/config/cmip6_handler.py
@@ -34,8 +34,6 @@ class CMIP6Handler(BasicHandler):
         BasicHandler.__init__(self, name, path, Session, validate=validate, offline=offline)
 
 
-    createCim = True
-
 
     def openPath(self, path):
         """Open a sample path, returning a project-specific file object,

--- a/src/python/esgcet/esgcet/config/cmip6_handler.py
+++ b/src/python/esgcet/esgcet/config/cmip6_handler.py
@@ -34,6 +34,8 @@ class CMIP6Handler(BasicHandler):
         BasicHandler.__init__(self, name, path, Session, validate=validate, offline=offline)
 
 
+    createCim = True
+
 
     def openPath(self, path):
         """Open a sample path, returning a project-specific file object,

--- a/src/python/esgcet/esgcet/publish/__init__.py
+++ b/src/python/esgcet/esgcet/publish/__init__.py
@@ -5,9 +5,10 @@ from extract import extractFromDataset, aggregateVariables, CREATE_OP, DELETE_OP
 from utility import filelistIterator, fnmatchIterator, fnIterator, directoryIterator, multiDirectoryIterator,\
     nodeIterator, progressCallback, StopEvent, readDatasetMap, datasetMapIterator, iterateOverDatasets,\
     processIterator, processNodeMatchIterator, checksum, extraFieldsGet, parseDatasetVersionId,\
-    generateDatasetVersionId, compareFilesByPath, establish_pid_connection, bcolors, checkAndUpdateRepo
+    generateDatasetVersionId, compareFilesByPath, establish_pid_connection, bcolors, checkAndUpdateRepo, tracebackString
 from thredds import generateThredds, reinitializeThredds, generateThreddsOutputPath, updateThreddsMasterCatalog, updateThreddsRootCatalog
 from hessianlib import Hessian, RemoteCallException
 from unpublish import deleteDatasetList, DELETE, UNPUBLISH, NO_OPERATION, UNINITIALIZED
 from replica import scanDirectory, generateReplicaThreddsCatalog, publishCatalogs
 from rest import RestPublicationService
+from cim import create_cim_from_dmap

--- a/src/python/esgcet/esgcet/publish/cim.py
+++ b/src/python/esgcet/esgcet/publish/cim.py
@@ -1,0 +1,86 @@
+"""
+esgcet wrapper to cdf2cim.
+
+Provides create_cim_from_dmap.
+
+Imports cdf2cim, but only if and when create_cim_from_dmap is actually called, so if import fails,
+publisher can still be run without it.
+"""
+
+import os
+import sys
+from utility import tracebackString
+
+
+class Cdf2cimWrapper:
+
+    cdf2cim = None
+
+    def _do_import(self):
+        if self.cdf2cim == None:
+            self.cdf2cim = __import__("cdf2cim")    
+
+    def create_cim_from_dmap(self, dmap):
+        """
+        Call cdf2cim with a starting directory which is the deepest common parent directory 
+        for the set of files listed in the map file.
+        The map file ought only contain one dataset ID, but if it contains more than one, 
+        call cdf2cim for each separately.
+        """
+
+        if not dmap:
+            print "WARNING: Empty map file.  cdf2cim will not be run."
+            return
+
+        self._do_import()
+
+        if len(dmap) > 1:
+            print "WARNING: Dataset map contains more than one dataset."
+            print "         Will run cdf2cim separately for each."
+
+        failures = ""
+        for top_dir in self._yield_starting_directories(dmap):
+            try:
+                self._call_cdf2cim(top_dir)
+            except:
+                failures += "While running cdf2cim on 'top_dir':\n%s" % tracebackString(indent=5)
+
+        if failures:
+            raise Exception(failures)
+    
+    def _yield_starting_directories(self, dmap):
+        for (dsid, version), values in dmap.items():
+            paths = [path for path, size in values]
+            # allow for ignoring dataset with no files (though impossible with current map file syntax)
+            if not paths:
+                continue
+            start_dir = self._deepest_common_parent(paths)
+            print "INFO: for dataset ID %s," % dsid
+            print "      top dir for create-cim is %s" % start_dir
+            yield start_dir
+
+    def _call_cdf2cim(self, starting_directory):
+        # not sure what the interface will be...
+        self.cdf2cim.blah(starting_directory)  # FIXME...
+
+    def _deepest_common_parent(self, paths):
+        common_substring = self._longest_common_substring([os.path.normpath(p) for p in paths])
+
+        # substring will either end in either be /path/to/dir/ or /path/to/dir/common_file_stem
+        # in either case dirname will return /path/to/dir
+        return os.path.dirname(common_substring)
+
+    def _longest_common_substring(self, strings):
+        """
+        longest substring at start of all the strings
+        """
+        s = ""
+        for chars in zip(*strings):
+            cset = set(chars)
+            if len(cset) > 1:  # differences found
+                break
+            s += cset.pop()
+        return s
+
+
+create_cim_from_dmap = Cdf2cimWrapper().create_cim_from_dmap

--- a/src/python/esgcet/esgcet/publish/cim.py
+++ b/src/python/esgcet/esgcet/publish/cim.py
@@ -60,8 +60,8 @@ class Cdf2cimWrapper:
             yield start_dir
 
     def _call_cdf2cim(self, starting_directory):
-        # not sure what the interface will be...
-        self.cdf2cim.blah(starting_directory)  # FIXME...
+        self.cdf2cim.scan(starting_directory)
+        self.cdf2cim.publish()
 
     def _deepest_common_parent(self, paths):
         common_substring = self._longest_common_substring([os.path.normpath(p) for p in paths])

--- a/src/python/esgcet/esgcet/publish/utility.py
+++ b/src/python/esgcet/esgcet/publish/utility.py
@@ -7,6 +7,8 @@ import types
 import string
 import glob
 import re
+import sys
+import traceback
 import logging
 import subprocess
 import filecmp
@@ -1011,6 +1013,15 @@ def getRestServiceURL(project_config_section=None):
         host = urlparse.urlparse(hessianServiceURL).netloc
         serviceURL = urlparse.urlunparse(('https', host, '/esg-search/ws', '', '', ''))
     return serviceURL
+
+
+def tracebackString(indent=0):
+    """
+    Returns the traceback of the current exception as an indented string.
+    """
+    lines = traceback.format_exc(sys.exc_info()[2]).split("\n")
+    prefix = " " * indent
+    return string.join([prefix + line + "\n" for line in lines])
 
 
 def establish_pid_connection(pid_prefix, test_publication, project_config_section, config, handler, publish=True):

--- a/src/python/esgcet/scripts/esgpublish
+++ b/src/python/esgcet/scripts/esgpublish
@@ -530,9 +530,9 @@ def main(argv):
 
     if createCim == None:
         try:
-            hander_create_cim = handler.createCim
+            handler_create_cim = handler.createCim
         except AttributeError:
-            hander_create_cim = False
+            handler_create_cim = False
 
         if handler_create_cim:
             createCim = (datasetMapfile != None and not publishOnly)

--- a/src/python/esgcet/scripts/esgpublish
+++ b/src/python/esgcet/scripts/esgpublish
@@ -612,7 +612,7 @@ def main(argv):
                     except:
                         print "WARNING: --create-cim failed:\n"
                         print tracebackString(indent=10)
-                    print "Continuing with publication after --create-cim failure:\n"
+                        print "Continuing with publication after --create-cim failure:\n"
 
             elif rescan:
                 # Note: No need to get the extra fields, such as mod_time, since

--- a/src/python/esgcet/scripts/esgpublish
+++ b/src/python/esgcet/scripts/esgpublish
@@ -13,7 +13,7 @@ from sqlalchemy.orm import sessionmaker
 from esgcet.publish import extractFromDataset, aggregateVariables, filelistIterator, fnmatchIterator, fnIterator, directoryIterator, \
     multiDirectoryIterator, progressCallback, StopEvent, readDatasetMap, datasetMapIterator, iterateOverDatasets, publishDatasetList, \
     processIterator, processNodeMatchIterator, CREATE_OP, DELETE_OP, RENAME_OP, UPDATE_OP, REPLACE_OP, reinitializeThredds, \
-    updateThreddsMasterCatalog, establish_pid_connection, bcolors
+    updateThreddsMasterCatalog, establish_pid_connection, bcolors, create_cim_from_dmap, tracebackString
 from esgcet.config import loadConfig, getHandler, getHandlerByName, initLogging, registerHandlers, splitLine, getOfflineLister, getThreddsServiceSpecs
 from esgcet.exceptions import *
 from esgcet.messaging import debug, info, warning, error, critical, exception
@@ -58,6 +58,18 @@ Options:
 
     -c, --create
         Create and publish a dataset containing the files listed in the directory or dataset map.
+
+    --create-cim
+        Can only be used in conjunction with --map. Calls cdf2cim as
+        an initial step before publication to the database, to create 
+        CIM records.  The cdf2cim script will scan for data files below a 
+        given starting directory, which will be the deepest common parent
+        directory of the data files listed in the map file.  If
+        filesystem layout recommendations for CMIP6 are followed, it
+        will find the same set of data files as listed in the map file.
+
+    --create-cim-only
+        As --create-cim, but does not actually publish the dataset.
 
     --echo-sql: Echo SQL commands
 
@@ -279,13 +291,15 @@ def summarize_errors(Session, datasetNames):
 def main(argv):
 
     try:
-        args, lastargs = getopt.getopt(argv, "a:cdehi:m:p:ru", ['append', 'create', 'dataset=', 'delete-files', 'echo-sql', 'experiment=', 'filter=', 'help', 'keep-credentials', 'keep-version', 'log=', 'map=', 'message=', 'model=', 'offline',  'parent=', 'per-time', 'per-variable', 'project=', 'property=', 'publish', 'new-version=', 'no-thredds-reinit', 'noscan', 'read-directories', 'read-files', 'rename-files', 'replace', 'replica=', 'rest-api', 'service=', 'set-replica', 'summarize-errors', 'test', 'thredds', 'thredds-reinit', 'update', 'use-existing=', 'use-list=', 'validate=', 'version-list=', 'nodbwrite'])
+        args, lastargs = getopt.getopt(argv, "a:cdehi:m:p:ru", ['append', 'create', 'create-cim', 'create-cim-only', 'dataset=', 'delete-files', 'echo-sql', 'experiment=', 'filter=', 'help', 'keep-credentials', 'keep-version', 'log=', 'map=', 'message=', 'model=', 'offline',  'parent=', 'per-time', 'per-variable', 'project=', 'property=', 'publish', 'new-version=', 'no-thredds-reinit', 'noscan', 'read-directories', 'read-files', 'rename-files', 'replace', 'replica=', 'rest-api', 'service=', 'set-replica', 'summarize-errors', 'test', 'thredds', 'thredds-reinit', 'update', 'use-existing=', 'use-list=', 'validate=', 'version-list=', 'nodbwrite'])
     except getopt.error:
         print sys.exc_value
         print usage
         sys.exit(0)
 
     aggregateDimension = "time"
+    createCim = False
+    createCimOnly = False
     datasetMapfile = None
     datasetName = None
     echoSql = False
@@ -329,6 +343,10 @@ def main(argv):
             publishOp = UPDATE_OP
         elif flag in ['-c', '--create']:
             publishOp = CREATE_OP
+        elif flag == '--create-cim':
+            createCim = True
+        elif flag == '--create-cim-only':
+            createCimOnly = True        
         elif flag=='--dataset':
             datasetName = arg
         elif flag in ['-d', '--delete-files']:
@@ -455,6 +473,12 @@ def main(argv):
     if version is not None and versionList is not None:
         raise ESGPublishError("Cannot specify both --new-version and --version-list")
 
+    if createCim and datasetMapfile == None:
+        raise ESGPublishError("--create-cim can only be used with --map")
+
+    if createCimOnly and datasetMapfile == None:
+        raise ESGPublishError("--create-cim-only can only be used with --map")
+
     if versionList is not None:
         version = {}
         f = open(versionList)
@@ -466,7 +490,14 @@ def main(argv):
             dsid = dsid.strip()
             vers = int(vers.strip())
             version[dsid] = vers
-
+    
+    # if --create-cim-only specified, just do this and quit without 
+    # starting database interaction etc
+    if createCimOnly:
+        dmap = readDatasetMap(datasetMapfile)
+        create_cim_from_dmap(dmap)
+        sys.exit(0)  # assume it raised an exception if it failed
+        
     # Register project handlers
     registerHandlers(projectName)
 
@@ -542,6 +573,14 @@ def main(argv):
             if datasetMapfile is not None:
                 dmap, extraFields = readDatasetMap(datasetMapfile, parse_extra_fields=True)
                 datasetNames = dmap.keys()
+
+                if createCim:
+                    try:
+                        create_cim_from_dmap(dmap)
+                    except:
+                        print "WARNING: --create-cim failed:\n"
+                        print tracebackString(indent=10)
+                    print "Continuing with publication after --create-cim failure:\n"
 
             elif rescan:
                 # Note: No need to get the extra fields, such as mod_time, since

--- a/src/python/esgcet/scripts/esgpublish
+++ b/src/python/esgcet/scripts/esgpublish
@@ -72,7 +72,7 @@ Options:
 
             - Command line option --create-cim or --no-create-cim take precedence.
 
-            - If no command-line option, and the project handler has createCim=True, then call
+            - If no command-line option, and the project ini file has create_cim=true, then call
               cdf2cim if --map is specified and --noscan is not supplied, ensuring that it is called
               before the scan phase but is not repeated if publication is done in stages.
 

--- a/src/python/esgcet/scripts/esgpublish
+++ b/src/python/esgcet/scripts/esgpublish
@@ -522,7 +522,7 @@ def main(argv):
     if restApi is None:
         restApi = config.getboolean('DEFAULT', 'use_rest_api', default=False)
 
-    project_config_section = "config:%s" % projectName
+    project_config_section = "project:%s" % projectName
 
     handler = getHandlerByName(projectName, None, Session, offline=offline)
 

--- a/src/python/esgcet/scripts/esgpublish
+++ b/src/python/esgcet/scripts/esgpublish
@@ -60,13 +60,23 @@ Options:
         Create and publish a dataset containing the files listed in the directory or dataset map.
 
     --create-cim
-        Can only be used in conjunction with --map. Calls cdf2cim as
-        an initial step before publication to the database, to create 
-        CIM records.  The cdf2cim script will scan for data files below a 
-        given starting directory, which will be the deepest common parent
-        directory of the data files listed in the map file.  If
-        filesystem layout recommendations for CMIP6 are followed, it
-        will find the same set of data files as listed in the map file.
+        Can only be used in conjunction with --map. Calls cdf2cim as an initial step before
+        publication to the database, to create CIM records.
+
+        The cdf2cim script will scan for data files below a given starting directory, which will 
+        be the deepest common parent directory of the data files listed in the map file.  If 
+        filesystem layout recommendations for CMIP6 are followed, it will find the same set of
+        data files as listed in the map file.
+
+        The decision whether to call cdf2cim is determined as follows:
+
+            - Command line option --create-cim or --no-create-cim take precedence.
+
+            - If no command-line option, and the project handler has createCim=True, then call
+              cdf2cim if --map is specified and --noscan is not supplied, ensuring that it is called
+              before the scan phase but is not repeated if publication is done in stages.
+
+            - If neither of the above apply, default is not to run cdf2cim.
 
     --create-cim-only
         As --create-cim, but does not actually publish the dataset.
@@ -124,6 +134,9 @@ Options:
         Specify the dataset version number, a positive integer. If unspecified, the version number is
         set to 1 for new datasets, and is incremented by 1 for existing datasets. Use this option
         with caution, as the version number will apply to all datasets processed. See --keep-version and --version-list.
+
+    --no-create-cim
+        Do not call cd2fcim.  See --create-cim for more details.
 
     --nodbwrite
          Scan the files, but do not write the dataset to the postgres database.  This option should not be used with --noscan, --thredds, --publish, as it is intended for "dry-runs" to validate metadata.
@@ -291,14 +304,14 @@ def summarize_errors(Session, datasetNames):
 def main(argv):
 
     try:
-        args, lastargs = getopt.getopt(argv, "a:cdehi:m:p:ru", ['append', 'create', 'create-cim', 'create-cim-only', 'dataset=', 'delete-files', 'echo-sql', 'experiment=', 'filter=', 'help', 'keep-credentials', 'keep-version', 'log=', 'map=', 'message=', 'model=', 'offline',  'parent=', 'per-time', 'per-variable', 'project=', 'property=', 'publish', 'new-version=', 'no-thredds-reinit', 'noscan', 'read-directories', 'read-files', 'rename-files', 'replace', 'replica=', 'rest-api', 'service=', 'set-replica', 'summarize-errors', 'test', 'thredds', 'thredds-reinit', 'update', 'use-existing=', 'use-list=', 'validate=', 'version-list=', 'nodbwrite'])
+        args, lastargs = getopt.getopt(argv, "a:cdehi:m:p:ru", ['append', 'create', 'create-cim', 'create-cim-only', 'dataset=', 'delete-files', 'echo-sql', 'experiment=', 'filter=', 'help', 'keep-credentials', 'keep-version', 'log=', 'map=', 'message=', 'model=', 'offline',  'parent=', 'per-time', 'per-variable', 'project=', 'property=', 'publish', 'new-version=', 'no-create-cim', 'no-thredds-reinit', 'noscan', 'read-directories', 'read-files', 'rename-files', 'replace', 'replica=', 'rest-api', 'service=', 'set-replica', 'summarize-errors', 'test', 'thredds', 'thredds-reinit', 'update', 'use-existing=', 'use-list=', 'validate=', 'version-list=', 'nodbwrite'])
     except getopt.error:
         print sys.exc_value
         print usage
         sys.exit(0)
 
     aggregateDimension = "time"
-    createCim = False
+    createCim = None  # default (behaviour depends on various options and project handler), not same as False
     createCimOnly = False
     datasetMapfile = None
     datasetName = None
@@ -343,10 +356,14 @@ def main(argv):
             publishOp = UPDATE_OP
         elif flag in ['-c', '--create']:
             publishOp = CREATE_OP
+        elif flag in ('--create-cim', '--no-create-cim', '--create-cim-only') and (createCim != None or createCimOnly):
+            raise ESGPublishError('--create-cim/--no-create-cim/--create-cim-only are mutually exclusive')
         elif flag == '--create-cim':
             createCim = True
+        elif flag == '--no-create-cim':
+            createCim = False
         elif flag == '--create-cim-only':
-            createCimOnly = True        
+            createCimOnly = True
         elif flag=='--dataset':
             datasetName = arg
         elif flag in ['-d', '--delete-files']:
@@ -506,6 +523,21 @@ def main(argv):
         restApi = config.getboolean('DEFAULT', 'use_rest_api', default=False)
 
     handler = getHandlerByName(projectName, None, Session, offline=offline)
+
+    # set createCim to True or False based on handler and options, 
+    # unless argument parsing has already found an explicit option that overrides this 
+    # (--create-cim / --no-create-cim / --create-cim-only)
+
+    if createCim == None:
+        try:
+            hander_create_cim = handler.createCim
+        except AttributeError:
+            hander_create_cim = False
+
+        if handler_create_cim:
+            createCim = (datasetMapfile != None and not publishOnly)
+        else:
+            createCim = False
 
     # check cert and generate a new one, if expired
     if publish and not keep_credentials:

--- a/src/python/esgcet/scripts/esgpublish
+++ b/src/python/esgcet/scripts/esgpublish
@@ -522,19 +522,15 @@ def main(argv):
     if restApi is None:
         restApi = config.getboolean('DEFAULT', 'use_rest_api', default=False)
 
+    project_config_section = "config:%s" % projectName
+
     handler = getHandlerByName(projectName, None, Session, offline=offline)
 
     # set createCim to True or False based on handler and options, 
     # unless argument parsing has already found an explicit option that overrides this 
     # (--create-cim / --no-create-cim / --create-cim-only)
-
     if createCim == None:
-        try:
-            handler_create_cim = handler.createCim
-        except AttributeError:
-            handler_create_cim = False
-
-        if handler_create_cim:
+        if config.getboolean(project_config_section, 'create_cim', default=False):
             createCim = (datasetMapfile != None and not publishOnly)
         else:
             createCim = False
@@ -553,7 +549,6 @@ def main(argv):
 
     # Check if project uses PIDs and start messaging thread
     pid_connector = None
-    project_config_section = "config:%s" % projectName
     try:
         if not publishOnly or thredds:
             pid_prefix = handler.check_pid_avail(project_config_section, config, version=version)


### PR DESCRIPTION
The CIM integration is now tested for a variety of use cases, and seems to call cdf2cim when it should and not when it shouldn't, and when run in an appropriate test environment, cdf2cim seems to work appropriately when it is called.


**OPTIONS ADDED:**

* `--create-cim`

   Can only be used in conjunction with --map. Calls cdf2cim as an
   initial step before publication to the database, to create CIM
   records.

   The cdf2cim script will scan for data files below a given starting
   directory, which will be the deepest common parent directory of the
   data files listed in the map file.  If filesystem layout
   recommendations for CMIP6 are followed, it will find the same set of
   data files as listed in the map file.

   The decision whether to call cdf2cim is determined as follows:

       * Command line option --create-cim or --no-create-cim take
         precedence.

       * If no command-line option, and the project ini file has
         create_cim=true, then call cdf2cim if --map is specified and
         --noscan is not supplied, ensuring that it is called before the
         scan phase but is not repeated if publication is done in stages.

       * If neither of the above apply, default is not to run cdf2cim.

* `--create-cim-only`

    As --create-cim, but does not actually publish the dataset.

* `--no-create-cim`

    Do not call cd2fcim.  See --create-cim for more details.

**TESTS DONE**

See https://docs.google.com/document/d/1Cv36him5AkMaZ4z9wJoP71V5Zd54PEASl_aL-oV4sm8/edit, last section.

